### PR TITLE
Support for linux and other systems

### DIFF
--- a/Source/SaveMoverModule.cs
+++ b/Source/SaveMoverModule.cs
@@ -101,16 +101,16 @@ public class SaveMoverModule : EverestModule {
                     // Copy to temp
 
                     // Glob all mod files
-                    string searchDirectory = "./Saves";
+                    string searchDirectory = UserIO.SavePath.Replace("\\", "/");
                     DirectoryInfo dir = new DirectoryInfo(searchDirectory);
 
                     List<Tuple<string, string>> movedFiles = new List<Tuple<string, string>>();  
                     foreach (var file in dir.EnumerateFiles($"{menuData.StartSlot}-*.celeste").Concat(dir.EnumerateFiles($"{menuData.StartSlot}.celeste"))) {
                         var regex = new Regex(Regex.Escape($"{menuData.StartSlot}"));
                         string movedPath = regex.Replace(file.Name, $"{self.SlotIndex}", 1);
-                        string tempPath = $"./Saves/temp_{file.Name}";
-                        movedFiles.Add(new Tuple<string, string>(tempPath, $"./Saves/{movedPath}"));
-                        File.Move($"./Saves/{file.Name}", tempPath);
+                        string tempPath = searchDirectory + $"/temp_{file.Name}";
+                        movedFiles.Add(new Tuple<string, string>(tempPath, searchDirectory + $"/{movedPath}"));
+                        File.Move(searchDirectory + $"/{file.Name}", tempPath);
                     }
 
                     if (menuData.StartSlot > self.SlotIndex) {
@@ -118,7 +118,7 @@ public class SaveMoverModule : EverestModule {
                             foreach(var file in dir.EnumerateFiles($"{i}-*.celeste").Concat(dir.EnumerateFiles($"{i}.celeste"))) {
                                 var regex = new Regex(Regex.Escape($"{i}"));
                                 string movedPath = regex.Replace(file.Name, $"{i+1}", 1);
-                                File.Move($"./Saves/{file.Name}", $"./Saves/{movedPath}");
+                                File.Move(searchDirectory + $"/{file.Name}", searchDirectory + $"/{movedPath}");
                             }
                         }
                     } else if (menuData.StartSlot < self.SlotIndex) {
@@ -126,7 +126,7 @@ public class SaveMoverModule : EverestModule {
                             foreach(var file in dir.EnumerateFiles($"{i+1}-*.celeste").Concat(dir.EnumerateFiles($"{i+1}.celeste"))) {
                                 var regex = new Regex(Regex.Escape($"{i+1}"));
                                 string movedPath = regex.Replace(file.Name, $"{i}", 1);
-                                File.Move($"./Saves/{file.Name}", $"./Saves/{movedPath}");
+                                File.Move(searchDirectory + $"/{file.Name}", searchDirectory + $"/{movedPath}");
                             }
                         }
                     }


### PR DESCRIPTION
This addresses this [issue](https://github.com/whatsGravity/SaveMoverMod/issues/5).

It just changes the previously used "./Saves" directory to UserIO.SavePath.Replace("\\", "/") (not sure if sanitization is needed or not), and also references searchDirectory instead of mentioning ./Saves elsewhere.

I took UserIO.SavePath from IzumisQOL and I have no idea why it works and if it really does.